### PR TITLE
Reconcile bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ bundles:
 ```
 where each entry under `bundles` corresponds to a resource bundle that you want to manage with this tool
 * Run `translator --generate` to begin using the tool
+
+# Enhancements
+* Everywhere snapshot_file is referred to, should probably change to snapshot_file_name because that's what the bundle object returns
+* The reconciliator assumes order of insertion into a dictionary is preserved. When the processor parses all the files and converts them to a dictionary representation, the reconciliator assumes that this was done in order. Key value pairs in the dictionary representation outputted by the processor should appear in the same order they originally show up in the file
+* Rename the tool to not be so boring :D
+* Parallelize all the bundle operations. Can use threads or asyncio for this

--- a/src/main/resources/resources_de.json
+++ b/src/main/resources/resources_de.json
@@ -1,4 +1,4 @@
 {
-    "test.name" : "German key test",
-    "test.description" : "single key value pair test for properties files"
+    "test.name": "German key test",
+    "test.description": "single key value pair test for properties files"
 }

--- a/translator
+++ b/translator
@@ -7,7 +7,8 @@ import yaml
 import json
 
 program = os.path.basename(sys.argv[0])
-config_file = 'translation-config.yml'
+config_file = "translation-config.yml"
+
 
 class Driver:
     def main(self, args=sys.argv[1:], prog=program):
@@ -22,35 +23,40 @@ class Driver:
 
     def parse_args(self, args, prog):
         parser = argparse.ArgumentParser(
-            prog=prog,
-            description='Generator for candidate translation strings',
+            prog=prog, description="Generator for candidate translation strings",
         )
 
-        parser.add_argument('--output',
-                            help='output type',
-                            choices=("yaml", "json"),
-                            default="yaml")
+        parser.add_argument(
+            "--output", help="output type", choices=("yaml", "json"), default="json"
+        )
 
         mode = parser.add_mutually_exclusive_group(required=True)
-        mode.add_argument('--generate',
-                          help='generate snapshot file',
-                          action='store_true', default=False)
-        mode.add_argument('--reconcile',
-                          help='sanitize locale files',
-                          action='store_true', default=False)
+        mode.add_argument(
+            "--generate",
+            help="generate snapshot file",
+            action="store_true",
+            default=False,
+        )
+        mode.add_argument(
+            "--reconcile",
+            help="sanitize locale files",
+            action="store_true",
+            default=False,
+        )
         return parser.parse_args(args)
 
     def load_config(self):
         if os.path.exists(config_file):
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 data = yaml.full_load(f)
         return data
 
+
 class JsonProcessor(object):
-    '''
+    """
         Processor that can convert json content in files to a python
         dictionary keyed with the file name
-    '''
+    """
 
     def __init__(self, files):
         self.files = set(files)
@@ -63,16 +69,23 @@ class JsonProcessor(object):
             self.dict_representation[file] = dictdump
 
     def get_as_dictionary(self):
-        self.parse_to_dict(files)
+        self.parse_to_dict(self.files)
         return self.dict_representation
 
+    @classmethod
+    def dump_to_file(cls, contents, filename):
+        with open(filename, "w") as outfile:
+            json.dump(contents, outfile, indent=4)
+
+
 class PropertiesProcessor(object):
-    '''
+    """
         Processor that can convert a properties file to a python
         dictionary keyed with the file name
-    '''
-    separator = '='
-    comment_char='#'
+    """
+
+    separator = "="
+    comment_char = "#"
 
     def __init__(self, files):
         self.files = set(files)
@@ -87,7 +100,9 @@ class PropertiesProcessor(object):
                     if l and not l.startswith(self.comment_char):
                         key_value_split = l.split(self.separator)
                         key = key_value_split[0].strip()
-                        value = self.separator.join(key_value_split[1:]).strip().strip('"')
+                        value = (
+                            self.separator.join(key_value_split[1:]).strip().strip('"')
+                        )
                         if value:
                             current_file_key_val[key] = value
             self.dict_representation[file] = current_file_key_val
@@ -95,6 +110,13 @@ class PropertiesProcessor(object):
     def get_as_dictionary(self):
         self.parse_to_dict(self.files)
         return self.dict_representation
+
+    @classmethod
+    def dump_to_file(cls, contents, filename):
+        with open(filename, "w") as outfile:
+            for key, value in contents.items():
+                print(f"{key}={value}", file=outfile)
+
 
 class Bundle(object):
     whoami = __qualname__
@@ -105,10 +127,10 @@ class Bundle(object):
         self.files = set(files)
         self.default_locale = default_locale or "en_US"
         # Processing related variables
-        self.snapshot_file = ''
-        self.default_locale_file = ''
+        self.snapshot_file = ""
+        self.default_locale_file = ""
         self.bundle_as_dictionary = {}
-        self. missing_items = {}
+        self.missing_items = {}
         self.added_items = {}
 
     def get_default_locale_file(self):
@@ -117,24 +139,24 @@ class Bundle(object):
 
         locale_regex_match = []
         for file in self.files:
-            '''
+            """
                 This regex matches all files that have _{default_locale} in their
                 filename but not if that file also contains the word snapshot. This
                 is to prevent the regex matching of the snapshot file when looking
                 for the default locale file
-            '''
-            if re.match(rf'.*_{self.default_locale}(?!(.*snapshot)).*', file):
+            """
+            if re.match(rf".*_{self.default_locale}(?!(.*snapshot)).*", file):
                 locale_regex_match.append(file)
         if len(locale_regex_match) > 1:
             sys.exit(
-                f'{self.whoami}: There were multiple regex matches of '
-                + f'_{self.default_locale} in {self.path}: {locale_regex_match}. '
-                + f'Expecting only a single match'
+                f"{self.whoami}: There were multiple regex matches of "
+                + f"_{self.default_locale} in {self.path}: {locale_regex_match}. "
+                + f"Expecting only a single match"
             )
         elif len(locale_regex_match) == 0:
             sys.exit(
-                f'{self.whoami}: Expected default locale file to match regex '
-                + f'.*_{self.default_locale} but no files in {self.path} matched'
+                f"{self.whoami}: Expected default locale file to match regex "
+                + f".*_{self.default_locale} but no files in {self.path} matched"
             )
         else:
             return locale_regex_match[0]
@@ -144,95 +166,112 @@ class Bundle(object):
             return self.snapshot_file
 
         default_locale_path = self.get_default_locale_file()
-        snapshot_file_path = ''.join((default_locale_path, '.snapshot'))
+        snapshot_file_path = "".join((default_locale_path, ".snapshot"))
         if not os.path.exists(snapshot_file_path):
             print(
-                f'generating snapshot file {snapshot_file_path} '
-                + f'based on {default_locale_path}'
+                f"generating snapshot file {snapshot_file_path} "
+                + f"based on {default_locale_path}"
             )
-            with open(snapshot_file_path, 'a') as snap, open(default_locale_path, 'r') as default:
+            with open(snapshot_file_path, "a") as snap, open(default_locale_path, "r") as default:
                 for line in default:
                     snap.write(line)
         if snapshot_file_path not in self.files:
             self.files.add(snapshot_file_path)
         return snapshot_file_path
 
-    def convert_to_dictionary(self):
+    def get_as_dictionary(self):
         if self.bundle_as_dictionary:
             return self.bundle_as_dictionary
 
-        if self.extension == 'json':
+        if self.extension == "json":
             self.bundle_as_dictionary = JsonProcessor(self.files).get_as_dictionary()
-        elif self.extension == 'properties':
+        elif self.extension == "properties":
             self.bundle_as_dictionary = PropertiesProcessor(self.files).get_as_dictionary()
         else:
             sys.exit(
-                f'{self.whoami}: Bundle type of {self.extension} is not one of the supported types')
+                f"{self.whoami}: Bundle type of {self.extension} is not one of the supported types"
+            )
         return self.bundle_as_dictionary
 
     # Find all items that exist in the snapshot but not in a locale file
     def get_missing_items_in_bundle(self):
-        bundle_as_dictionary = self.convert_to_dictionary()
+        bundle_as_dictionary = self.get_as_dictionary()
         snapshot_file = self.get_snapshot_file()
         snapshot = bundle_as_dictionary[snapshot_file]
         for file in bundle_as_dictionary.keys():
             candidate = bundle_as_dictionary[file]
-            missing = [f'{key}: {val}' for key, val in snapshot.items() if key not in candidate.keys()]
+            missing = [
+                f"{key}: {val}"
+                for key, val in snapshot.items()
+                if key not in candidate.keys()
+            ]
             if missing:
                 self.missing_items[file] = missing
         return self.missing_items
 
     # Find all items that exist in the default locale file but not the snapshot
     def get_added_items_in_bundle(self):
-        bundle_as_dictionary = self.convert_to_dictionary()
+        bundle_as_dictionary = self.get_as_dictionary()
         snapshot_file = self.get_snapshot_file()
         snapshot = bundle_as_dictionary[snapshot_file]
         default_locale_file = self.get_default_locale_file()
         default = bundle_as_dictionary[default_locale_file]
 
         if default != snapshot:
-            new_values = [f'{key}: {val}' for key, val in default.items() if default[key] not in snapshot.values()]
-            '''
+            new_values = [
+                f"{key}: {val}"
+                for key, val in default.items()
+                if default[key] not in snapshot.values()
+            ]
+            """
                 TODO: Ignoring the capability to actually make an inplace
                 edit on the default locale file for any key value pair.
                 With the logic currently implemented, this will show up
                 simply as a "new addition" and the snapshot file will
                 become stale with the old key that was actually "removed"
                 in the default locale file. How do we reconcile this?
-            '''
+            """
             if new_values:
                 self.added_items[default_locale_file] = new_values
         return self.added_items
+
 
 class Bundler:
     all_bundles = []
 
     def add_to_all_bundles(self, bundle):
-        path = bundle.get('path')
-        extension = bundle.get('extension')
-        default_locale = bundle.get('default_locale')
+        path = bundle.get("path")
+        extension = bundle.get("extension")
+        default_locale = bundle.get("default_locale")
         resolved_path = Utilities().resolve_path(path)
         all_files_in_bundle_path = []
         for file in os.listdir(resolved_path):
             if file.endswith(extension):
                 file_path = os.path.join(resolved_path, file)
                 all_files_in_bundle_path.append(file_path)
-        bundle_object = Bundle(path=resolved_path, extension=extension, files=all_files_in_bundle_path, default_locale=default_locale)
+        bundle_object = Bundle(
+            path=resolved_path,
+            extension=extension,
+            files=all_files_in_bundle_path,
+            default_locale=default_locale,
+        )
         self.all_bundles.append(bundle_object)
 
     def gather(self, data):
-        for bundle in data.get('bundles'):
+        for bundle in data.get("bundles"):
             self.add_to_all_bundles(bundle)
         for bundle_obj in self.all_bundles:
             bundle_obj.get_snapshot_file()
         return self.all_bundles
 
+
 class TranslationGenerator:
-    '''
+    """
         Accepts a list of Bundle objects and apply the necessary parser
         to generate all the differences between the default_locale, it's corresponding
         snapshot and all the other locales
-    '''
+    """
+
     whoami = __qualname__
     all_bundles = []
     additions = []
@@ -252,6 +291,7 @@ class TranslationGenerator:
                 self.additions.append(added_items)
         Manifest(self.options).print_manifest(self.missing, self.additions)
 
+
 class Manifest:
     data = {}
 
@@ -266,18 +306,20 @@ class Manifest:
             self.data["missing"] = self.data.get("missing") or []
             self.data["missing"].append(missed)
 
-        if self.options.output == 'json' and self.data:
+        if self.options.output == "json" and self.data:
             print(json.dumps(self.data, indent=4))
-        elif self.options.output == 'yaml' and self.data:
+        elif self.options.output == "yaml" and self.data:
             print(yaml.dump(self.data))
 
+
 class Reconciliator:
-    '''
+    """
         Accepts a list of bundle objects and self-heals every
         file in each bundle with their respective snapshot/default
         locale files. Intended to be run often to preserve the correct
         state of all the files
-    '''
+    """
+
     whoami = __qualname__
 
     def __init__(self, options, all_bundles):
@@ -286,53 +328,93 @@ class Reconciliator:
 
     def reconcile(self):
         for bundle in self.all_bundles:
-            self.balance(bundle)
+            bundle_as_dictionary = bundle.get_as_dictionary()
+            snapshot = bundle.get_snapshot_file()
+            default = bundle.get_default_locale_file()
+            other_locales = list(
+                filter(
+                    lambda key: (key != snapshot and key != default),
+                    bundle_as_dictionary.keys(),
+                )
+            )
+            self.remove_stale_entries(bundle, snapshot)
 
-    def balance(self, bundle):
-        snapshot = bundle.get_snapshot_file()
+    """
+        Remove all entries in files within bundles that don't
+        have a corresponding key in the snapshot file. Ignore
+        the default locale in this check as that file is assumed
+        to be unclean and with state drift from the snapshot
+    """
 
-    def alphabetize(self, file):
+    def remove_stale_entries(self, bundle, snapshot):
+        bundle_as_dictionary = bundle.get_as_dictionary()
+        for file in bundle_as_dictionary.keys():
+            keys_in_locale = bundle_as_dictionary[file].keys()
+            stale_keys = [
+                key
+                for key in keys_in_locale
+                if key not in bundle_as_dictionary[snapshot].keys()
+            ]
+            if stale_keys:
+                for key in stale_keys:
+                    print(f"Deleting stale key '{key}' from {file}")
+                    del bundle_as_dictionary[file][key]
+                self.write_back_to_file(bundle, bundle_as_dictionary[file], file)
+
+    def write_back_to_file(self, bundle, contents, file):
+        temp_file_name = file + ".new"
+        if bundle.extension == "json":
+            JsonProcessor.dump_to_file(contents, temp_file_name)
+        elif bundle.extension == "properties":
+            PropertiesProcessor.dump_to_file(contents, temp_file_name)
+        else:
+            sys.exit(
+                f"{self.whoami}: Bundle type of {self.extension} is not one of the supported types"
+            )
+        os.rename(temp_file_name, file)
         return
 
 
 class Validator:
     whoami = __qualname__
+
     def validate(self, data):
-        ACCEPTED_FILE_TYPES = {'properties', 'json'}
-        if data and 'bundles' in data and data.get('bundles'):
-            for bundle in data.get('bundles'):
+        ACCEPTED_FILE_TYPES = {"properties", "json"}
+        if data and "bundles" in data and data.get("bundles"):
+            for bundle in data.get("bundles"):
                 self.validate_keys_in_bundle(bundle)
-                path = Utilities().resolve_path(bundle.get('path'))
+                path = Utilities().resolve_path(bundle.get("path"))
                 if not os.path.exists(path):
-                    sys.exit(
-                        f'{self.whoami}: {path} does not exist'
-                    )
-                extension = bundle.get('extension')
+                    sys.exit(f"{self.whoami}: {path} does not exist")
+                extension = bundle.get("extension")
                 if extension not in ACCEPTED_FILE_TYPES:
                     sys.exit(
-                        f'{self.whoami}: .{extension} files are not one of the supported types\n' +
-                        ', '.join(sorted(ACCEPTED_FILE_TYPES))
+                        f"{self.whoami}: .{extension} files are not one of the supported types\n"
+                        + ", ".join(sorted(ACCEPTED_FILE_TYPES))
                     )
                 for fname in os.listdir(path):
                     if fname.endswith(extension):
                         break
                 else:
-                    sys.exit(f'{self.whoami}: no .{extension} file found in {path}')
+                    sys.exit(f"{self.whoami}: no .{extension} file found in {path}")
         else:
-            sys.exit(f'{self.whoami}: {config_file} does not have any bundles')
+            sys.exit(f"{self.whoami}: {config_file} does not have any bundles")
 
     def validate_keys_in_bundle(self, bundle):
-       REQUIRED_KEYS = {'path', 'extension'}
-       if REQUIRED_KEYS - set(bundle.keys()):
-           sys.exit(
-               f'{self.whoami}: bundle configuration must have keys ' +
-                ', '.join(sorted(REQUIRED_KEYS)))
+        REQUIRED_KEYS = {"path", "extension"}
+        if REQUIRED_KEYS - set(bundle.keys()):
+            sys.exit(
+                f"{self.whoami}: bundle configuration must have keys "
+                + ", ".join(sorted(REQUIRED_KEYS))
+            )
+
 
 class Utilities:
     def resolve_path(self, path):
         return os.path.realpath(path)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     try:
         Driver().main()
     except KeyboardInterrupt:


### PR DESCRIPTION
reconciliator checks all non-default/non-snapshot locales for extra keys
that do not exist in the snapshot file. This is almost certainly an
undesired state and so we reconcile the bundle file to at most only have
the keys that currently exist in the snapshot